### PR TITLE
Add ZIO clients for Maelstrom provided service nodes

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -190,6 +190,39 @@ You can send an error message to any node id as a reply to another message. Here
 [Send custom error](../../examples/echo/src/main/scala/com/example/ErrorDocs.scala) inside_block:ReplyCustomError
 <!--/codeinclude-->
 
+## Maelstrom services
+
+Maelstrom starts some services at the beginning of every simulation by default
+
+These are their node ids:
+
+1. lin-kv
+2. lww-kv
+3. seq-kv
+4. lin-tso
+
+You can read more these services on the [maelstrom docs](https://github.com/jepsen-io/maelstrom/blob/main/doc/services.md)
+
+ZIO-Maelstrom provides `LinkKv`, `LwwKv`, `SeqKv` & `LinTso` clients to interact with these services. 
+
+<!--codeinclude-->
+[Key value store](../../examples/echo/src/main/scala/com/example/KvStoreDocs.scala) inside_block:SeqKvExample
+<!--/codeinclude--> 
+
+`SeqKv`, `LwwKv` & `LinKv` are all key value stores. They have the same api but different consistency guarantees.
+
+!!! note
+    `read`, `write` and `cas` apis are all built on top of [`ask`](#4-ask) api. So they can return an `AskError` which you may need to handle. According to [maelstrom documentation](https://github.com/jepsen-io/maelstrom/blob/main/doc/workloads.md#rpc-cas), they can return `KeyDoesNotExist` or `PreconditionFailed` error codes.
+
+!!! tip
+    key and value of the key value store can be any type that has a `zio.json.JsonCodec` instance
+
+[`LinTso`](https://github.com/jepsen-io/maelstrom/blob/main/doc/services.md#lin-tso) is a linearizable timestamp oracle. It has the following api
+
+<!--codeinclude-->
+[Linearizable timestamp oracle](../../examples/echo/src/main/scala/com/example/TsoDocs.scala) inside_block:TsoExample
+<!--/codeinclude-->
+
 ## Settings
 
 Below are the settings that can be configured for a node

--- a/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
+++ b/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
@@ -1,0 +1,22 @@
+package com.example.kvstore
+
+import com.bilalfazlani.zioMaelstrom.*
+import com.bilalfazlani.zioMaelstrom.protocol.*
+import zio.*
+
+object SeqKvExample {
+  val newMessageId = Random.nextInt.map(MessageId(_))
+
+  val program: ZIO[MaelstromRuntime, AskError, Unit] = for
+    msgId1        <- newMessageId
+    _             <- SeqKv.write("counter", 1, msgId1, 5.seconds)
+    msgId2        <- newMessageId
+    counterValue1 <- SeqKv.read[Int]("counter", msgId2, 5.seconds)
+    _             <- logInfo(s"counter value is $counterValue1")
+    msgId3        <- newMessageId
+    _             <- SeqKv.cas("counter", 1, 3, false, msgId3, 5.seconds)
+    msgId4        <- newMessageId
+    counterValue2 <- SeqKv.read[Int]("counter", msgId4, 5.seconds)
+    _             <- logInfo(s"counter value is $counterValue2")
+  yield ()
+}

--- a/examples/echo/src/main/scala/com/example/TsoDocs.scala
+++ b/examples/echo/src/main/scala/com/example/TsoDocs.scala
@@ -1,0 +1,13 @@
+package com.example.tso
+
+import com.bilalfazlani.zioMaelstrom.*
+import com.bilalfazlani.zioMaelstrom.protocol.*
+import zio.*
+
+object TsoExample {
+  val program: ZIO[MaelstromRuntime, AskError, Unit] = for
+    msgId1    <- Random.nextIntBounded(Int.MaxValue).map(MessageId(_))
+    timestamp <- LinTso.ts(msgId1, 5.seconds)
+    _         <- logInfo(s"timestamp is $timestamp")
+  yield ()
+}

--- a/todo.md
+++ b/todo.md
@@ -1,11 +1,13 @@
 PENDING: 
 
+- [ ] auto message ids
+- [ ] docs for services
 - [ ] Test kit docs
-- [ ] Api ref docs
+- [x] Api ref docs
 - [ ] Tests
   - [X] Test overlap in console output manually tested
   - [X] Test resource safety in callbackRegistry manually tested
-  - [ ] Automated tests
+  - [x] Automated tests
 - [ ] Out messages should not need to define types. Use class name. May need to use macros
 
 TBD:

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/MaelstromRuntime.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/MaelstromRuntime.scala
@@ -3,8 +3,11 @@ package com.bilalfazlani.zioMaelstrom
 import zio.{Scope, ZLayer}
 import java.nio.file.Path
 
+type Services = LinKv & SeqKv & LwwKv & LinTso
+
 // definition {
-type MaelstromRuntime = Initialisation & RequestHandler & MessageSender & Logger & Settings
+type MaelstromRuntime = Initialisation & RequestHandler & MessageSender & Services & Logger &
+  Settings
 // }
 
 object MaelstromRuntime:
@@ -26,6 +29,11 @@ object MaelstromRuntime:
       inputStream,
       OutputChannel.stdOut,
       CallbackRegistry.live,
+      // Services
+      LinKv.live,
+      SeqKv.live,
+      LwwKv.live,
+      LinTso.live,
 
       // effectful layers
       contextLayer,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
@@ -1,0 +1,66 @@
+package com.bilalfazlani.zioMaelstrom
+
+import zio.*
+import zio.json.*
+import protocol.*
+
+private[zioMaelstrom] trait KvService:
+  def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Value]
+  def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit]
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit]
+
+private[zioMaelstrom] case class KvImpl(
+    remote: NodeId,
+    sender: MessageSender
+) extends KvService {
+  override def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Value] =
+    sender
+      .ask[KvRead[Key], KvReadOk[Value]](KvRead(key, messageId), remote, timeout)
+      .map(_.value)
+
+  override def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    sender
+      .ask[KvWrite[Key, Value], KvWriteOk](KvWrite(key, value, messageId), remote, timeout)
+      .unit
+
+  override def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    sender
+      .ask[CompareAndSwap[Key, Value], CompareAndSwapOk](
+        CompareAndSwap(key, from, to, createIfNotExists, messageId),
+        remote,
+        timeout
+      )
+      .unit
+}

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvMessages.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvMessages.scala
@@ -1,0 +1,40 @@
+package com.bilalfazlani.zioMaelstrom
+
+import zio.*
+import zio.json.*
+import protocol.*
+
+private[zioMaelstrom] case class KvRead[Key](key: Key, msg_id: MessageId, `type`: String = "read")
+    extends NeedsReply,
+      Sendable derives JsonEncoder
+
+private[zioMaelstrom] case class KvReadOk[Value](
+    in_reply_to: MessageId,
+    value: Value
+) extends Reply
+    derives JsonDecoder
+
+private[zioMaelstrom] case class KvWrite[Key, Value](
+    key: Key,
+    value: Value,
+    msg_id: MessageId,
+    `type`: String = "write"
+) extends NeedsReply,
+      Sendable
+    derives JsonEncoder
+
+private[zioMaelstrom] case class KvWriteOk(in_reply_to: MessageId) extends Reply derives JsonDecoder
+
+private[zioMaelstrom] case class CompareAndSwap[Key, Value](
+    key: Key,
+    from: Value,
+    to: Value,
+    create_if_not_exists: Boolean,
+    msg_id: MessageId,
+    `type`: String = "cas"
+) extends NeedsReply,
+      Sendable
+    derives JsonEncoder
+
+private[zioMaelstrom] case class CompareAndSwapOk(in_reply_to: MessageId) extends Reply
+    derives JsonDecoder

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -1,0 +1,41 @@
+package com.bilalfazlani.zioMaelstrom
+
+import protocol.*
+import zio.*
+import zio.json.*
+
+trait LinKv extends KvService
+
+object LinKv:
+  def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[LinKv, AskError, Value] =
+    ZIO.serviceWithZIO[LinKv](_.read(key, messageId, timeout))
+  
+  def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[LinKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LinKv](_.write(key, value, messageId, timeout))
+  
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[LinKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LinKv](_.cas(key, from, to, createIfNotExists, messageId, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, LinKv] = ZLayer.fromZIO(
+    for
+      sender <- ZIO.service[MessageSender]
+      kvImpl = KvImpl(NodeId("lin-kv"), sender)
+    yield new LinKv:
+      export kvImpl.*
+  )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -7,13 +7,8 @@ import zio.json.*
 trait LinKv extends KvService
 
 object LinKv:
-  def read[Key: JsonEncoder, Value: JsonDecoder](
-      key: Key,
-      messageId: MessageId,
-      timeout: Duration
-  ): ZIO[LinKv, AskError, Value] =
-    ZIO.serviceWithZIO[LinKv](_.read(key, messageId, timeout))
-  
+  def read[Value] = PartiallyAppliedKvRead[LinKv, Value]()
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -21,7 +16,7 @@ object LinKv:
       timeout: Duration
   ): ZIO[LinKv, AskError, Unit] =
     ZIO.serviceWithZIO[LinKv](_.write(key, value, messageId, timeout))
-  
+
   def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinTso.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinTso.scala
@@ -1,0 +1,22 @@
+package com.bilalfazlani.zioMaelstrom
+
+import protocol.*
+import zio.*
+import zio.json.*
+
+private case class Ts(msg_id: MessageId, `type`: String = "ts") extends Sendable, NeedsReply
+    derives JsonEncoder
+private case class TsOk(in_reply_to: MessageId, ts: Long) extends Reply derives JsonDecoder
+
+trait LinTso:
+  def ts(messageId: MessageId, timeout: Duration): ZIO[Any, AskError, Long]
+
+object LinTso:
+  def ts(messageId: MessageId, timeout: Duration): ZIO[LinTso, AskError, Long] =
+    ZIO.serviceWithZIO(_.ts(messageId, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, LinTso] = ???
+
+private case class LinTsoImpl(sender: MessageSender) extends LinTso:
+  def ts(messageId: MessageId, timeout: Duration): ZIO[Any, AskError, Long] =
+    sender.ask[Ts, TsOk](Ts(messageId), NodeId("lin-tso"), timeout).map(_.ts)

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinTso.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinTso.scala
@@ -15,7 +15,8 @@ object LinTso:
   def ts(messageId: MessageId, timeout: Duration): ZIO[LinTso, AskError, Long] =
     ZIO.serviceWithZIO(_.ts(messageId, timeout))
 
-  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, LinTso] = ???
+  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, LinTso] = 
+    ZLayer.fromFunction(LinTsoImpl.apply)
 
 private case class LinTsoImpl(sender: MessageSender) extends LinTso:
   def ts(messageId: MessageId, timeout: Duration): ZIO[Any, AskError, Long] =

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -7,13 +7,8 @@ import zio.json.*
 trait LwwKv extends KvService
 
 object LwwKv:
-  def read[Key: JsonEncoder, Value: JsonDecoder](
-      key: Key,
-      messageId: MessageId,
-      timeout: Duration
-  ): ZIO[LwwKv, AskError, Value] =
-    ZIO.serviceWithZIO[LwwKv](_.read(key, messageId, timeout))
-  
+  def read[Value] = PartiallyAppliedKvRead[LwwKv, Value]()
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -21,7 +16,7 @@ object LwwKv:
       timeout: Duration
   ): ZIO[LwwKv, AskError, Unit] =
     ZIO.serviceWithZIO[LwwKv](_.write(key, value, messageId, timeout))
-  
+
   def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -1,0 +1,41 @@
+package com.bilalfazlani.zioMaelstrom
+
+import protocol.*
+import zio.*
+import zio.json.*
+
+trait LwwKv extends KvService
+
+object LwwKv:
+  def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[LwwKv, AskError, Value] =
+    ZIO.serviceWithZIO[LwwKv](_.read(key, messageId, timeout))
+  
+  def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[LwwKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LwwKv](_.write(key, value, messageId, timeout))
+  
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      messageId: MessageId,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[LwwKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LwwKv](_.cas(key, from, to, createIfNotExists, messageId, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, LwwKv] = ZLayer.fromZIO(
+    for
+      sender <- ZIO.service[MessageSender]
+      kvImpl = KvImpl(NodeId("lww-kv"), sender)
+    yield new LwwKv:
+      export kvImpl.*
+  )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -1,0 +1,41 @@
+package com.bilalfazlani.zioMaelstrom
+
+import protocol.*
+import zio.*
+import zio.json.*
+
+trait SeqKv extends KvService
+
+object SeqKv:
+  def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[SeqKv, AskError, Value] =
+    ZIO.serviceWithZIO[SeqKv](_.read(key, messageId, timeout))
+  
+  def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[SeqKv, AskError, Unit] =
+    ZIO.serviceWithZIO[SeqKv](_.write(key, value, messageId, timeout))
+  
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[SeqKv, AskError, Unit] =
+    ZIO.serviceWithZIO[SeqKv](_.cas(key, from, to, createIfNotExists, messageId, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender, Nothing, SeqKv] = ZLayer.fromZIO(
+    for
+      sender <- ZIO.service[MessageSender]
+      kvImpl = KvImpl(NodeId("seq-kv"), sender)
+    yield new SeqKv:
+      export kvImpl.*
+  )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -7,13 +7,8 @@ import zio.json.*
 trait SeqKv extends KvService
 
 object SeqKv:
-  def read[Key: JsonEncoder, Value: JsonDecoder](
-      key: Key,
-      messageId: MessageId,
-      timeout: Duration
-  ): ZIO[SeqKv, AskError, Value] =
-    ZIO.serviceWithZIO[SeqKv](_.read(key, messageId, timeout))
-  
+  def read[Value] = PartiallyAppliedKvRead[SeqKv, Value]()
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -21,7 +16,7 @@ object SeqKv:
       timeout: Duration
   ): ZIO[SeqKv, AskError, Unit] =
     ZIO.serviceWithZIO[SeqKv](_.write(key, value, messageId, timeout))
-  
+
   def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/RPCTest.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/RPCTest.scala
@@ -4,7 +4,8 @@ import zio.test.*
 import zio.*
 import com.bilalfazlani.zioMaelstrom.protocol.*
 import zio.json.*
-import TestRuntime.*
+import testkit.TestRuntime
+import testkit.TestRuntime.*
 
 object RPCTest extends ZIOSpecDefault {
   def isCI        = sys.env.get("CI").contains("true")

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/RequestHandlerTests.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/RequestHandlerTests.scala
@@ -3,7 +3,8 @@ package com.bilalfazlani.zioMaelstrom
 import zio.test.*
 import zio.*
 import zio.json.*
-import TestRuntime.*
+import testkit.TestRuntime
+import testkit.TestRuntime.*
 import com.bilalfazlani.zioMaelstrom.protocol.*
 
 object RequestHandlerTest extends ZIOSpecDefault {

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
@@ -1,0 +1,69 @@
+package com.bilalfazlani.zioMaelstrom
+package testkit
+
+import zio.*
+import zio.json.*
+import protocol.*
+
+case class KvFake(ref: Ref.Synchronized[Map[Any, Any]]) extends KvService:
+  override def read[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Value] =
+    ref.get.map(_.get(key).get.asInstanceOf[Value])
+
+  override def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    ref.update(_ + (key -> value)).unit
+
+  override def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      messageId: MessageId,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    ref.updateZIO { map =>
+      map.get(key) match {
+        case Some(`from`)              => ZIO.succeed(map + (key -> to))
+        case None if createIfNotExists => ZIO.succeed(map + (key -> to))
+        case None =>
+          ZIO.fail(ErrorMessage(messageId, ErrorCode.KeyDoesNotExist, s"Key $key does not exist"))
+        case Some(other) =>
+          ZIO.fail(
+            ErrorMessage(
+              messageId,
+              ErrorCode.PreconditionFailed,
+              s"Expected $from but found $other"
+            )
+          )
+      }
+    }
+
+object KvFake:
+  val linKv = ZLayer.fromZIO(Ref.Synchronized.make(Map.empty[Any, Any]).map { r =>
+    val impl = KvFake(r)
+    new LinKv {
+      export impl.*
+    }
+  })
+
+  val seqKv = ZLayer.fromZIO(Ref.Synchronized.make(Map.empty[Any, Any]).map { r =>
+    val impl = KvFake(r)
+    new SeqKv {
+      export impl.*
+    }
+  })
+
+  val lwwKv = ZLayer.fromZIO(Ref.Synchronized.make(Map.empty[Any, Any]).map { r =>
+    val impl = KvFake(r)
+    new LwwKv {
+      export impl.*
+    }
+  })

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/LinTsoFake.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/LinTsoFake.scala
@@ -1,0 +1,16 @@
+package com.bilalfazlani.zioMaelstrom
+package testkit
+
+import zio.*
+import protocol.*
+
+case class LinTsoFake(ref: Ref[Long]) extends LinTso:
+  override def ts(messageId: MessageId, timeout: Duration): ZIO[Any, AskError, Long] =
+    ref.updateAndGet(_ + 1)
+
+object LinTsoFake:
+  val make = ZLayer.fromZIO(Ref.make(0L).map { r =>
+    val impl = LinTsoFake(r)
+    new LinTso:
+      export impl.*
+  })

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/TestRuntime.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/TestRuntime.scala
@@ -1,4 +1,5 @@
 package com.bilalfazlani.zioMaelstrom
+package testkit
 
 import zio.*
 import protocol.*
@@ -24,6 +25,11 @@ object TestRuntime:
       InputStream.queue,   // FAKE
       InputChannel.live,
       CallbackRegistry.live,
+      // Services
+      KvFake.linKv,
+      KvFake.seqKv,
+      KvFake.lwwKv,
+      LinTsoFake.make,
 
       // effectful layers
       Initialisation.fake(context), // FAKE


### PR DESCRIPTION
This PR adds zio clients for 

1. lin-kv 
1. lww-kv 
1. seq-kv
1. lin-tso 

more info here : https://github.com/jepsen-io/maelstrom/blob/main/doc/services.md

LinKv, LwwKv and SeqKv has the identical APIs

```scala
def read[Value]: PartiallyAppliedKvRead[?, Value]

def write[Key: JsonEncoder, Value: JsonEncoder](
      key: Key,
      value: Value,
      messageId: MessageId,
      timeout: Duration
  ): ZIO[?, AskError, Unit]

def cas[Key: JsonEncoder, Value: JsonEncoder](
      key: Key,
      from: Value,
      to: Value,
      createIfNotExists: Boolean,
      messageId: MessageId,
      timeout: Duration
  ): ZIO[?, AskError, Unit]
```

LinTso has only one API:
```scala
def ts(messageId: MessageId, timeout: Duration): ZIO[LinTso, AskError, Long]
```
