### PR TITLE
Kv service enhancements

### DIFF
--- a/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
+++ b/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
@@ -10,7 +10,7 @@ object SeqKvExample {
     _             <- SeqKv.write("counter", 1, 5.seconds)
     counterValue1 <- SeqKv.read[Int]("counter", 5.seconds)
     _             <- logInfo(s"counter value is $counterValue1")
-    _             <- SeqKv.cas[String, Int]("counter", 5.seconds)(_.fold(3)(_ + 3))
+    _             <- SeqKv.cas("counter", 1, 3, false, 5.seconds)
     counterValue2 <- SeqKv.read[Int]("counter", 5.seconds)
     _             <- logInfo(s"counter value is $counterValue2")
   yield ()

--- a/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
+++ b/examples/echo/src/main/scala/com/example/KvStoreDocs.scala
@@ -10,7 +10,7 @@ object SeqKvExample {
     _             <- SeqKv.write("counter", 1, 5.seconds)
     counterValue1 <- SeqKv.read[Int]("counter", 5.seconds)
     _             <- logInfo(s"counter value is $counterValue1")
-    _             <- SeqKv.cas("counter", 1, 3, false, 5.seconds)
+    _             <- SeqKv.cas[String, Int]("counter", 5.seconds)(_.fold(3)(_ + 3))
     counterValue2 <- SeqKv.read[Int]("counter", 5.seconds)
     _             <- logInfo(s"counter value is $counterValue2")
   yield ()

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
@@ -27,6 +27,14 @@ private[zioMaelstrom] trait KvService:
       timeout: Duration
   ): ZIO[Any, AskError, Unit]
 
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit]
+
   def cas[Key: JsonEncoder, Value: JsonCodec](
       key: Key,
       newValue: Option[Value] => Value,
@@ -144,7 +152,7 @@ private[zioMaelstrom] class KvImpl(
             }
     } yield ()
 
-  private def cas[Key: JsonEncoder, Value: JsonEncoder](
+  override def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,
       to: Value,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
@@ -27,14 +27,6 @@ private[zioMaelstrom] trait KvService:
       timeout: Duration
   ): ZIO[Any, AskError, Unit]
 
-  def cas[Key: JsonEncoder, Value: JsonEncoder](
-      key: Key,
-      from: Value,
-      to: Value,
-      createIfNotExists: Boolean,
-      timeout: Duration
-  ): ZIO[Any, AskError, Unit]
-
   def cas[Key: JsonEncoder, Value: JsonCodec](
       key: Key,
       newValue: Option[Value] => Value,
@@ -152,7 +144,7 @@ private[zioMaelstrom] class KvImpl(
             }
     } yield ()
 
-  override def cas[Key: JsonEncoder, Value: JsonEncoder](
+  private def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,
       to: Value,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvImpl.scala
@@ -10,7 +10,18 @@ private[zioMaelstrom] trait KvService:
       timeout: Duration
   ): ZIO[Any, AskError, Value]
 
+  def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: Duration
+  ): ZIO[Any, AskError, Option[Value]]
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit]
+
+  def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
       timeout: Duration
@@ -24,10 +35,25 @@ private[zioMaelstrom] trait KvService:
       timeout: Duration
   ): ZIO[Any, AskError, Unit]
 
+  def cas[Key: JsonEncoder, Value: JsonCodec](
+      key: Key,
+      newValue: Option[Value] => Value,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit]
+
+  // overall time taken by this method can be more than timeout
+  // because this method retries infinitely if precondition keeps failing
+  def casZIO[Key: JsonEncoder, Value: JsonCodec, R, E](
+      key: Key,
+      newValue: Option[Value] => ZIO[R, E, Value],
+      timeout: Duration
+  ): ZIO[R, AskError | E, Unit]
+
 private[zioMaelstrom] class KvImpl(
     private val remote: NodeId,
     private val sender: MessageSender,
-    private val messageIdStore: MessageIdStore
+    private val messageIdStore: MessageIdStore,
+    private val logger: Logger
 ) extends KvService {
 
   override def read[Key: JsonEncoder, Value: JsonDecoder](
@@ -38,6 +64,14 @@ private[zioMaelstrom] class KvImpl(
       sender
         .ask[KvRead[Key], KvReadOk[Value]](KvRead(key, messageId), remote, timeout)
         .map(_.value)
+    }
+
+  override def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: Duration
+  ): ZIO[Any, AskError, Option[Value]] =
+    read[Key, Value](key, timeout).map(Some(_)).catchSome {
+      case ErrorMessage(_, ErrorCode.KeyDoesNotExist, _, _) => ZIO.succeed(None)
     }
 
   override def write[Key: JsonEncoder, Value: JsonEncoder](
@@ -51,6 +85,73 @@ private[zioMaelstrom] class KvImpl(
         .unit
     }
 
+  override def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    messageIdStore.next.flatMap { messageId =>
+      sender
+        .ask[CompareAndSwap[Key, Value], CompareAndSwapOk](
+          CompareAndSwap(key, None, value, true, messageId),
+          remote,
+          timeout
+        )
+        .unit
+    }
+
+  private def casError(key: Any) = logger.debug(
+    s"an attempt to replace value for key $key failed due to a race condition. will attempt again with the new value"
+  )
+
+  override def cas[Key: JsonEncoder, Value: JsonCodec](
+      key: Key,
+      newValue: Option[Value] => Value,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    for {
+      current <- readOption[Key, Value](key, timeout)
+      newVal = newValue(current)
+      _ <- current match
+        case None =>
+          writeIfNotExists(key, newVal, timeout)
+            .catchSome { case ErrorMessage(_, ErrorCode.KeyAlreadyExists, _, _) =>
+              casError(key) *> cas(key, newValue, timeout)
+            }
+        case Some(value) =>
+          cas(key, value, newVal, false, timeout)
+            .catchSome {
+              case ErrorMessage(_, ErrorCode.PreconditionFailed, _, _) =>
+                casError(key) *> cas(key, newValue, timeout)
+              case ErrorMessage(_, ErrorCode.KeyDoesNotExist, _, _) =>
+                casError(key) *> cas(key, newValue, timeout)
+            }
+    } yield ()
+
+  override def casZIO[Key: JsonEncoder, Value: JsonCodec, R, E](
+      key: Key,
+      newValue: Option[Value] => ZIO[R, E, Value],
+      timeout: Duration
+  ): ZIO[R, AskError | E, Unit] =
+    for {
+      current <- readOption[Key, Value](key, timeout)
+      newVal  <- newValue(current)
+      _ <- current match
+        case None =>
+          writeIfNotExists(key, newVal, timeout)
+            .catchSome { case ErrorMessage(_, ErrorCode.KeyAlreadyExists, _, _) =>
+              casError(key) *> casZIO(key, newValue, timeout)
+            }
+        case Some(value) =>
+          cas(key, value, newVal, false, timeout)
+            .catchSome {
+              case ErrorMessage(_, ErrorCode.PreconditionFailed, _, _) =>
+                casError(key) *> casZIO(key, newValue, timeout)
+              case ErrorMessage(_, ErrorCode.KeyDoesNotExist, _, _) =>
+                casError(key) *> casZIO(key, newValue, timeout)
+            }
+    } yield ()
+
   override def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       from: Value,
@@ -61,7 +162,7 @@ private[zioMaelstrom] class KvImpl(
     messageIdStore.next.flatMap { messageId =>
       sender
         .ask[CompareAndSwap[Key, Value], CompareAndSwapOk](
-          CompareAndSwap(key, from, to, createIfNotExists, messageId),
+          CompareAndSwap(key, Some(from), to, createIfNotExists, messageId),
           remote,
           timeout
         )
@@ -75,3 +176,15 @@ class PartiallyAppliedKvRead[Kv <: KvService: Tag, Value] {
   ): ZIO[Kv, AskError, Value] =
     ZIO.serviceWithZIO[Kv](_.read[Key, Value](key, timeout))
 }
+
+case class PartiallyAppliedCas[Kv <: KvService: Tag, Key, Value](key: Key, timeout: Duration):
+  def apply(
+      newValue: Option[Value] => Value
+  )(using JsonEncoder[Key], JsonCodec[Value]): ZIO[Kv, AskError, Unit] =
+    ZIO.serviceWithZIO[Kv](_.cas(key, newValue, timeout))
+
+case class PartiallyAppliedCasZIO[Kv <: KvService: Tag, Key, Value](key: Key, timeout: Duration):
+  def apply[R, E](
+      newValue: Option[Value] => ZIO[R, E, Value]
+  )(using JsonEncoder[Key], JsonCodec[Value]): ZIO[Kv & R, AskError | E, Unit] =
+    ZIO.serviceWithZIO[Kv](_.casZIO(key, newValue, timeout))

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvMessages.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/KvMessages.scala
@@ -26,7 +26,7 @@ private[zioMaelstrom] case class KvWriteOk(in_reply_to: MessageId) extends Reply
 
 private[zioMaelstrom] case class CompareAndSwap[Key, Value](
     key: Key,
-    from: Value,
+    from: Option[Value],
     to: Value,
     create_if_not_exists: Boolean,
     msg_id: MessageId,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -8,6 +8,11 @@ trait LinKv extends KvService
 object LinKv:
   def read[Value] = PartiallyAppliedKvRead[LinKv, Value]()
 
+  def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[LinKv](_.readOption(key, timeout))
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -24,12 +29,29 @@ object LinKv:
   ): ZIO[LinKv, AskError, Unit] =
     ZIO.serviceWithZIO[LinKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore, Nothing, LinKv] =
+  def cas[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCas[LinKv, Key, Value](key, timeout)
+
+  def casZIO[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCasZIO[LinKv, Key, Value](key, timeout)
+
+  def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[LinKv](_.writeIfNotExists(key, value, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore & Logger, Nothing, LinKv] =
     ZLayer(
       for
         sender         <- ZIO.service[MessageSender]
         messageIdStore <- ZIO.service[MessageIdStore]
-        kvImpl = KvImpl(NodeId("lin-kv"), sender, messageIdStore)
+        logger         <- ZIO.service[Logger]
+        kvImpl = KvImpl(NodeId("lin-kv"), sender, messageIdStore, logger)
       yield new LinKv:
         export kvImpl.*
     )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -20,15 +20,6 @@ object LinKv:
   ): ZIO[LinKv, AskError, Unit] =
     ZIO.serviceWithZIO[LinKv](_.write(key, value, timeout))
 
-  def cas[Key: JsonEncoder, Value: JsonEncoder](
-      key: Key,
-      from: Value,
-      to: Value,
-      createIfNotExists: Boolean,
-      timeout: Duration
-  ): ZIO[LinKv, AskError, Unit] =
-    ZIO.serviceWithZIO[LinKv](_.cas(key, from, to, createIfNotExists, timeout))
-
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -20,6 +20,15 @@ object LinKv:
   ): ZIO[LinKv, AskError, Unit] =
     ZIO.serviceWithZIO[LinKv](_.write(key, value, timeout))
 
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[LinKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LinKv](_.cas(key, from, to, createIfNotExists, timeout))
+
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LinKv.scala
@@ -29,15 +29,15 @@ object LinKv:
   ): ZIO[LinKv, AskError, Unit] =
     ZIO.serviceWithZIO[LinKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  def cas[Key, Value](
+  def update[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCas[LinKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdate[LinKv, Key, Value](key, timeout)
 
-  def casZIO[Key, Value](
+  def updateZIO[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCasZIO[LinKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdateZIO[LinKv, Key, Value](key, timeout)
 
   def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -29,15 +29,15 @@ object LwwKv:
   ): ZIO[LwwKv, AskError, Unit] =
     ZIO.serviceWithZIO[LwwKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  def cas[Key, Value](
+  def update[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCas[LwwKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdate[LwwKv, Key, Value](key, timeout)
 
-  def casZIO[Key, Value](
+  def updateZIO[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCasZIO[LwwKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdateZIO[LwwKv, Key, Value](key, timeout)
 
   def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -8,6 +8,11 @@ trait LwwKv extends KvService
 object LwwKv:
   def read[Value] = PartiallyAppliedKvRead[LwwKv, Value]()
 
+  def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[LwwKv](_.readOption(key, timeout))
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -24,12 +29,29 @@ object LwwKv:
   ): ZIO[LwwKv, AskError, Unit] =
     ZIO.serviceWithZIO[LwwKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore, Nothing, LwwKv] =
+  def cas[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCas[LwwKv, Key, Value](key, timeout)
+
+  def casZIO[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCasZIO[LwwKv, Key, Value](key, timeout)
+
+  def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[LwwKv](_.writeIfNotExists(key, value, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore & Logger, Nothing, LwwKv] =
     ZLayer(
       for
         sender         <- ZIO.service[MessageSender]
         messageIdStore <- ZIO.service[MessageIdStore]
-        kvImpl = KvImpl(NodeId("lww-kv"), sender, messageIdStore)
+        logger         <- ZIO.service[Logger]
+        kvImpl = KvImpl(NodeId("lww-kv"), sender, messageIdStore, logger)
       yield new LwwKv:
         export kvImpl.*
     )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -20,15 +20,6 @@ object LwwKv:
   ): ZIO[LwwKv, AskError, Unit] =
     ZIO.serviceWithZIO[LwwKv](_.write(key, value, timeout))
 
-  def cas[Key: JsonEncoder, Value: JsonEncoder](
-      key: Key,
-      from: Value,
-      to: Value,
-      createIfNotExists: Boolean,
-      timeout: Duration
-  ): ZIO[LwwKv, AskError, Unit] =
-    ZIO.serviceWithZIO[LwwKv](_.cas(key, from, to, createIfNotExists, timeout))
-
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/LwwKv.scala
@@ -20,6 +20,15 @@ object LwwKv:
   ): ZIO[LwwKv, AskError, Unit] =
     ZIO.serviceWithZIO[LwwKv](_.write(key, value, timeout))
 
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[LwwKv, AskError, Unit] =
+    ZIO.serviceWithZIO[LwwKv](_.cas(key, from, to, createIfNotExists, timeout))
+
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -8,6 +8,11 @@ trait SeqKv extends KvService
 object SeqKv:
   def read[Value] = PartiallyAppliedKvRead[SeqKv, Value]()
 
+  def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[SeqKv](_.readOption(key, timeout))
+
   def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
@@ -24,12 +29,29 @@ object SeqKv:
   ): ZIO[SeqKv, AskError, Unit] =
     ZIO.serviceWithZIO[SeqKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore, Nothing, SeqKv] =
+  def cas[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCas[SeqKv, Key, Value](key, timeout)
+
+  def casZIO[Key, Value](
+      key: Key,
+      timeout: Duration
+  ) = PartiallyAppliedCasZIO[SeqKv, Key, Value](key, timeout)
+
+  def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: Duration
+  ) = ZIO.serviceWithZIO[SeqKv](_.writeIfNotExists(key, value, timeout))
+
+  private[zioMaelstrom] val live: ZLayer[MessageSender & MessageIdStore & Logger, Nothing, SeqKv] =
     ZLayer(
       for
         sender         <- ZIO.service[MessageSender]
         messageIdStore <- ZIO.service[MessageIdStore]
-        kvImpl = KvImpl(NodeId("seq-kv"), sender, messageIdStore)
+        logger         <- ZIO.service[Logger]
+        kvImpl = KvImpl(NodeId("seq-kv"), sender, messageIdStore, logger)
       yield new SeqKv:
         export kvImpl.*
     )

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -20,15 +20,6 @@ object SeqKv:
   ): ZIO[SeqKv, AskError, Unit] =
     ZIO.serviceWithZIO[SeqKv](_.write(key, value, timeout))
 
-  def cas[Key: JsonEncoder, Value: JsonEncoder](
-      key: Key,
-      from: Value,
-      to: Value,
-      createIfNotExists: Boolean,
-      timeout: Duration
-  ): ZIO[SeqKv, AskError, Unit] =
-    ZIO.serviceWithZIO[SeqKv](_.cas(key, from, to, createIfNotExists, timeout))
-
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -20,6 +20,15 @@ object SeqKv:
   ): ZIO[SeqKv, AskError, Unit] =
     ZIO.serviceWithZIO[SeqKv](_.write(key, value, timeout))
 
+  def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[SeqKv, AskError, Unit] =
+    ZIO.serviceWithZIO[SeqKv](_.cas(key, from, to, createIfNotExists, timeout))
+
   def cas[Key, Value](
       key: Key,
       timeout: Duration

--- a/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
+++ b/zio-maelstrom/src/main/scala/com/bilal-fazlani/zio-maelstrom/services/SeqKv.scala
@@ -29,15 +29,15 @@ object SeqKv:
   ): ZIO[SeqKv, AskError, Unit] =
     ZIO.serviceWithZIO[SeqKv](_.cas(key, from, to, createIfNotExists, timeout))
 
-  def cas[Key, Value](
+  def update[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCas[SeqKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdate[SeqKv, Key, Value](key, timeout)
 
-  def casZIO[Key, Value](
+  def updateZIO[Key, Value](
       key: Key,
       timeout: Duration
-  ) = PartiallyAppliedCasZIO[SeqKv, Key, Value](key, timeout)
+  ) = PartiallyAppliedUpdateZIO[SeqKv, Key, Value](key, timeout)
 
   def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
@@ -46,6 +46,34 @@ case class KvFake(ref: Ref.Synchronized[Map[Any, Any]], messageIdStore: MessageI
       }
     }
 
+  override def cas[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      from: Value,
+      to: Value,
+      createIfNotExists: Boolean,
+      timeout: Duration
+  ): ZIO[Any, AskError, Unit] =
+    ref.updateZIO { map =>
+      map.get(key) match {
+        case Some(`from`)              => ZIO.succeed(map + (key -> to))
+        case None if createIfNotExists => ZIO.succeed(map + (key -> to))
+        case None =>
+          messageIdStore.next.flatMap(messageId =>
+            ZIO.fail(ErrorMessage(messageId, ErrorCode.KeyDoesNotExist, s"Key $key does not exist"))
+          )
+        case Some(other) =>
+          messageIdStore.next.flatMap(messageId =>
+            ZIO.fail(
+              ErrorMessage(
+                messageId,
+                ErrorCode.PreconditionFailed,
+                s"Expected $from but found $other"
+              )
+            )
+          )
+      }
+    }
+
   override def cas[Key: JsonEncoder, Value: JsonCodec](
       key: Key,
       newValue: Option[Value] => Value,

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
@@ -46,34 +46,6 @@ case class KvFake(ref: Ref.Synchronized[Map[Any, Any]], messageIdStore: MessageI
       }
     }
 
-  override def cas[Key: JsonEncoder, Value: JsonEncoder](
-      key: Key,
-      from: Value,
-      to: Value,
-      createIfNotExists: Boolean,
-      timeout: Duration
-  ): ZIO[Any, AskError, Unit] =
-    ref.updateZIO { map =>
-      map.get(key) match {
-        case Some(`from`)              => ZIO.succeed(map + (key -> to))
-        case None if createIfNotExists => ZIO.succeed(map + (key -> to))
-        case None =>
-          messageIdStore.next.flatMap(messageId =>
-            ZIO.fail(ErrorMessage(messageId, ErrorCode.KeyDoesNotExist, s"Key $key does not exist"))
-          )
-        case Some(other) =>
-          messageIdStore.next.flatMap(messageId =>
-            ZIO.fail(
-              ErrorMessage(
-                messageId,
-                ErrorCode.PreconditionFailed,
-                s"Expected $from but found $other"
-              )
-            )
-          )
-      }
-    }
-
   override def cas[Key: JsonEncoder, Value: JsonCodec](
       key: Key,
       newValue: Option[Value] => Value,

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/KvFake.scala
@@ -12,12 +12,39 @@ case class KvFake(ref: Ref.Synchronized[Map[Any, Any]], messageIdStore: MessageI
   ): ZIO[Any, AskError, Value] =
     ref.get.map(_.get(key).get.asInstanceOf[Value])
 
+  override def readOption[Key: JsonEncoder, Value: JsonDecoder](
+      key: Key,
+      timeout: zio.Duration
+  ): ZIO[Any, AskError, Option[Value]] =
+    ref.get.map(_.get(key).map(_.asInstanceOf[Value]))
+
   override def write[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
       value: Value,
       timeout: Duration
   ): ZIO[Any, AskError, Unit] =
     ref.update(_ + (key -> value)).unit
+
+  override def writeIfNotExists[Key: JsonEncoder, Value: JsonEncoder](
+      key: Key,
+      value: Value,
+      timeout: zio.Duration
+  ): ZIO[Any, AskError, Unit] =
+    ref.updateZIO { map =>
+      map.get(key) match {
+        case Some(_) =>
+          messageIdStore.next.flatMap(messageId =>
+            ZIO.fail(
+              ErrorMessage(
+                messageId,
+                ErrorCode.PreconditionFailed,
+                s"Value for key $key already exists"
+              )
+            )
+          )
+        case None => ZIO.succeed(map + (key -> value))
+      }
+    }
 
   override def cas[Key: JsonEncoder, Value: JsonEncoder](
       key: Key,
@@ -46,6 +73,24 @@ case class KvFake(ref: Ref.Synchronized[Map[Any, Any]], messageIdStore: MessageI
           )
       }
     }
+
+  override def cas[Key: JsonEncoder, Value: JsonCodec](
+      key: Key,
+      newValue: Option[Value] => Value,
+      timeout: zio.Duration
+  ): ZIO[Any, AskError, Unit] =
+    ref.update { map =>
+      val current = map.get(key).map(_.asInstanceOf[Value])
+      val newVal  = newValue(current)
+      map + (key -> newVal)
+    }
+
+  override def casZIO[Key: JsonEncoder, Value: JsonCodec, R, E](key: Key, newValue: Option[Value] => ZIO[R, E, Value], timeout: zio.Duration): ZIO[R, AskError | E, Unit] = 
+    ref.updateZIO { map =>
+      val current = map.get(key).map(_.asInstanceOf[Value])
+      newValue(current).map(newVal => map + (key -> newVal))
+    }
+
 
 object KvFake:
 

--- a/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/TestRuntime.scala
+++ b/zio-maelstrom/src/test/scala/com/bilal-fazlani/zio-maelstrom/testkit/TestRuntime.scala
@@ -26,7 +26,7 @@ object TestRuntime:
       CallbackRegistry.live,
       MessageIdStore.live,
 
-      // Services
+      // Fake Services
       KvFake.linKv,
       KvFake.seqKv,
       KvFake.lwwKv,


### PR DESCRIPTION
Add below methods for KVStores

## `readOption`

This is more Scala idiomatic. If a key in a map does not exist, we should get an Option instead of error. `read` method will continue to be present with it's existing behaviour.

## `writeIfNotExists`

Insert only if a key does not exist. Othewise return `Precondition Failed` error. 
This is implemented using the original `cas` api. We pass a `nil` as `from` and a new value to be inserted. we set `create_if_not_exists` as true. 

when the key does exist, maelstrom compares it with `nil` and it returns false. This results in `Precondition Failed` error.
when key does not exist, maelstrom simply inserts it successfully

## `update`

This is a high level method and is built by combining existing `readOption`, `writeIfNotExists` and existing `cas` method

- the new method takes a lamda whose job is to take an `Option[A]` to `A`
- the method will read current value and feed it to lamda to generate new value
- it will then go to KV store to write new value using older `cas` method
- if the current value is None, `writeIfNotExists` method is used internally instead of `cas`
- if it fails due to race condition (`Precondition Failed` error), it will repeat the entire cycle again with a newly fetched value.
- The retry count is infinite
- These semantics are very similar to a `Ref` in ZIO
- The new method will never return `Precondition Failed` error and can take more than given `timeout` value since timeout only applies to one `ask`
- If it encounters any other error, it will terminate with that error and not retry

Question: Does it make sense to still expose the previous `cas` method?

## `updateZIO`

Effectful version of above method. The only difference is the lambda can return a ZIO[A] instead of A. 
Caution needs to taken while using this method because if the lambda performs a side effect, that side effect can happen multiple times as part of retries. 

---

# Tasks

- [x] Implementation
- [ ] Tests  (how do you test this? maelstrom does not support running server without a workload)
- [ ] Examples
- [ ] Documentation
